### PR TITLE
fix unmet npm dependency: browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/nathandao/ginatra",
   "devDependencies": {
-    "browserify": "^10.2.3",
+    "browserify": "^11.0.1",
     "reactify": "^1.1.1",
     "watchify": "^3.2.1"
   },


### PR DESCRIPTION
When attempting to install project node modules, npm outputs a warning about an unmet dependency:

``` sh
npm i
npm WARN unmet dependency /Users/USER/git/ginatra/node_modules/watchify requires browserify@'^11.0.1' but will load
npm WARN unmet dependency /Users/USER/git/ginatra/node_modules/browserify,
npm WARN unmet dependency which is version 10.2.6
```

Updating `browserify` version to ^11.0.1 fixes this issue.
